### PR TITLE
fix(Combobox): check children to display no options message

### DIFF
--- a/packages/strapi-design-system/src/Combobox/Combobox.tsx
+++ b/packages/strapi-design-system/src/Combobox/Combobox.tsx
@@ -263,7 +263,7 @@ export const ComboboxInput = React.forwardRef<ComboboxInputElement, ComboboxInpu
                   </OptionBox>
                 </ComboboxPrimitive.CreateItem>
               ) : null}
-              {!creatable && !loading ? (
+              {!children && !creatable && !loading ? (
                 <ComboboxPrimitive.NoValueFound asChild>
                   <OptionBox $hasHover={false}>
                     <Typography>{noOptionsMessage(internalTextValue ?? '')}</Typography>


### PR DESCRIPTION
Checking `!creatable && !loading` only should not be enough to display the "No options found" message.

If any children exist, unfortunately, it's displaying "No options found" after the children on the list.